### PR TITLE
Unify circle CI config across repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,28 @@ jobs:
         - /.*/
     docker:
       - image: docker:stable
-    working_directory: /root/imagemaster3000
+    working_directory: /root/working_directory
     steps:
       - run: apk add --no-cache git openssh
       - checkout
       - setup_remote_docker
       - run: |
+          git config --global --replace-all versionsort.prereleasesuffix ".alpha"
+          git config --global --add versionsort.prereleasesuffix ".beta"
+      - run: |
           TAG=${CIRCLE_TAG#v}
           BRANCH=${TAG/%.*/.x}
           VERSION=${TAG}
-          LATEST=$(git tag --sort=-refname | head -n 1)
+          LATEST=$(git tag --sort=-version:refname | head -n 1)
 
           docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-          docker build --build-arg branch=$BRANCH --build-arg version="$VERSION" -t misenko/imagemaster3000:$TAG .
-          docker push misenko/imagemaster3000:$TAG
+          docker build --build-arg branch=$BRANCH --build-arg version="$VERSION" -t $DOCKERHUB_REPO/$CIRCLE_PROJECT_REPONAME:$TAG ./$DOCKERFILE_DIR
+          docker push $DOCKERHUB_REPO/$CIRCLE_PROJECT_REPONAME:$TAG
 
           if [ "$LATEST" == "$CIRCLE_TAG" ]; then
-            docker tag misenko/imagemaster3000:$TAG misenko/imagemaster3000:latest
-            docker push misenko/imagemaster3000:latest
+            docker tag $DOCKERHUB_REPO/$CIRCLE_PROJECT_REPONAME:$TAG $DOCKERHUB_REPO/$CIRCLE_PROJECT_REPONAME:latest
+            docker push $DOCKERHUB_REPO/$CIRCLE_PROJECT_REPONAME:latest
           fi
 deployment:
   fake_deploy_for_cci2:


### PR DESCRIPTION
Changed workdir, tag sorting and DockerHub repository is now passed as variable from CI

(Don't forget to add $DOCKERHUB_REPO variable to circleCI)