### PR TITLE
added expires parameter to images

### DIFF
--- a/lib/imagemaster3000/image_list/templates/image_list.erb
+++ b/lib/imagemaster3000/image_list/templates/image_list.erb
@@ -14,6 +14,7 @@
           "dc:identifier":"<%= image.name %>",
           "ad:mpuri":"<%= Imagemaster3000::Settings[:'image-list-mpuri'] %>",
           "dc:title":"<%= image.name %>",
+          "dc:date:expires":"<%= (Time.now + 6.months).strftime('%Y-%m-%dT%H:%M:%SZ') %>",
           "hv:hypervisor":"QEMU-KVM",
 <% if image.ram -%>
           "hv:ram_minimum": "<%= image.ram %>",


### PR DESCRIPTION
After update of cloudkeeper to v0.7.0 `dc:date:expires` is mandatory parameter for each image in image list